### PR TITLE
Spec.9 updates

### DIFF
--- a/builder/api/building.py
+++ b/builder/api/building.py
@@ -25,6 +25,7 @@ import builder.api.definitions
 from builder.buildmain import setup
 from greent.graph_components import KNode
 from greent.util import LoggingUtil
+import re
 from builder.question import Question
 
 rosetta_config_file = os.path.join(os.path.dirname(__file__), "..", "..", "greent", "rosetta.yml")

--- a/builder/api/building.py
+++ b/builder/api/building.py
@@ -25,7 +25,7 @@ import builder.api.definitions
 from builder.buildmain import setup
 from greent.graph_components import KNode
 from greent.util import LoggingUtil
-import re
+from builder.question import Question
 
 rosetta_config_file = os.path.join(os.path.dirname(__file__), "..", "..", "greent", "rosetta.yml")
 properties_file = os.path.join(os.path.dirname(__file__), "..", "..", "greent", "conf", "annotation_map.yaml")
@@ -208,7 +208,7 @@ def synonymize_binding_nodes(answer_set, id_mappings):
 class NormalizeAnswerSet(Resource):
     def post(self):
         """
-        Adds synonmys to node and normalize edge db source for a json blob of answer knowledge graph.
+        Adds synonyms to node and normalize edge db source for a json blob of answer knowledge graph.
         ---
         tags: [util]
         requestBody:
@@ -235,6 +235,25 @@ api.add_resource(NormalizeAnswerSet, '/normalize')
 
 class Annotator(Resource):
     def get(self, node_id, node_type):
+        """
+        Returns annotation for a node.
+        ---
+        tags: [util]
+        parameters:
+            - in: path
+              name: node_id
+              description: "curie of the node"
+              schema:
+                type: string
+              required: true
+            - in: path
+              name: node_type
+              description: " Biolink type name for the curie, eg. providing chemical_substance here will make sure the
+               annotation is done as a chemical substance."
+              schema:
+                type: string
+              required: true
+        """
         node = KNode(id= node_id, type= node_type)
         greent_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
         sys.path.insert(0, greent_path)
@@ -507,6 +526,45 @@ class Concepts(Resource):
         return concepts
 
 api.add_resource(Concepts, '/concepts')
+
+
+class OperationPath(Resource):
+
+    def post(self):
+        """
+        Transpiles question graph to cypher and returns query operations path.
+        ---
+        tags: [build]
+        requestBody:
+            name: question
+            description: The machine-readable question graph.
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/definitions/Question'
+            required: true
+        responses:
+            200:
+                description: Concept based path graph
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                            - task id
+                            properties:
+                                task id:
+                                    type: string
+                                    description: task ID to poll for KG update status
+        """
+        q = Question(request.json)
+        r = rossetta_setup_default()
+
+        return q.get_edge_op_paths(r.type_graph)
+
+
+api.add_resource(OperationPath, '/operationpath')
+
 
 if __name__ == '__main__':
 

--- a/builder/api/definitions.py
+++ b/builder/api/definitions.py
@@ -4,16 +4,16 @@ API definitions
 
 from builder.api.setup import swagger
 from builder.util import FromDictMixin
-@swagger.definition('Node')
+@swagger.definition('QNode')
 class QNode(FromDictMixin):
     """
-    Node Object
+    QNode Object
     ---
-    id: Node
+    id: QNode
     required:
-        - id
+        - node_id
     properties:
-        id:
+        node_id:
             type: string
         type:
             type: string
@@ -30,12 +30,12 @@ class QNode(FromDictMixin):
     def dump(self):
         return {**vars(self)}
 
-@swagger.definition('Edge')
+@swagger.definition('QEdge')
 class QEdge(FromDictMixin):
     """
-    Edge Object
+    QEdge Object
     ---
-    id: Edge
+    id: QEdge
     required:
         - source_id
         - target_id
@@ -72,33 +72,33 @@ class Question(FromDictMixin):
       - nodes
       - edges
     properties:
-        machine_question:
+        query_graph:
             type: object
             properties:
                 nodes:
                     type: array
                     items:
-                        $ref: '#/definitions/Node'
+                        $ref: '#/definitions/QNode'
                 edges:
                     type: array
                     items:
-                        $ref: '#/definitions/Edge'
+                        $ref: '#/definitions/QEdge'
     example:
-        machine_question:
+        query_graph:
             nodes:
-              - id: n0
+              - node_id: n0
                 type: disease
                 curie: "MONDO:0005737"
                 name: "Ebola hemorrhagic fever"
-              - id: n1
+              - node_id: n1
                 type: gene
-              - id: n2
+              - node_id: n2
                 type: genetic_condition
             edges:
-              - id: e0
+              - edge_id: e0
                 source_id: n0
                 target_id: n1
-              - id: e1
+              - edge_id: e1
                 source_id: n1
                 target_id: n2
     """

--- a/builder/buildmain.py
+++ b/builder/buildmain.py
@@ -88,9 +88,9 @@ def build_spec(spec_sequence, start_name, start_id, end_name=None, end_id=None):
         natural = f'{spec_sequence}({start_name})'
 
     out = {"name": name,
-           "natural_question": natural, 
+           "original_question": natural,
            "notes": '',
-           "machine_question": machine_question
+           "query_graph": machine_question
     }
     return out
 
@@ -100,16 +100,16 @@ def build_step(spec, name=None, curie=None, id=0, eid=0):
             "type": spec,
             "name": name,
             "curie": curie,
-            "id": f'n{id}'
+            "node_id": f'n{id}'
         }
     else:
         node = {
             "type": spec,
-            "id": f'n{id}'
+            "node_id": f'n{id}'
         }
     if id:
         edge = {
-            "id": f'e{eid}',
+            "edge_id": f'e{eid}',
             "source_id": f'n{id-1}',
             "target_id": f'n{id}'
         }
@@ -125,18 +125,18 @@ def specs_from_array_of_ids(pathway, identifier_list, end_name, end_id):
             all_specs = build_spec(pathway, identifier.label, identifier.identifier, end_name=end_name, end_id=end_id)
         else:
             current_spec = build_spec(pathway, identifier.label, identifier.identifier, end_name=end_name, end_id= end_id)
-            for node in current_spec['machine_question']['nodes']:
+            for node in current_spec['query_graph']['nodes']:
                 node_id = int(node['id'][-1])
                 node['id'] = f'n{node_id + current_index}'
-                all_specs['machine_question']['nodes'].append(node)
-            for edge in current_spec['machine_question']['edges']:
+                all_specs['query_graph']['nodes'].append(node)
+            for edge in current_spec['query_graph']['edges']:
                 edge_id = int(edge['id'][-1])
                 source_id = int(edge['source_id'][-1])
                 target_id = int(edge['target_id'][-1])
                 edge['id'] = f'e{edge_id + current_index}'
                 edge['source_id']= f'n{source_id + current_index}'
                 edge['target_id']= f'n{target_id + current_index}'
-                all_specs['machine_question']['edges'].append(edge)
+                all_specs['query_graph']['edges'].append(edge)
             current_index += 2
     return all_specs
 


### PR DESCRIPTION
- Made QNodes and QEdges compliant with https://github.com/NCATS-Tangerine/NCATS-ReasonerStdAPI/blob/master/API/TranslatorReasonersAPI.yaml 
- Added a new api to expose paths of operations to be taken given a message with a query_graph.
- Annotation api was missing swagger doc.
- Buildermain now creates spec.9 compatible in buildspec steps, so it can be easily used to initialize Question Class in subsequent steps of its process. 